### PR TITLE
Reporting out of range reads as errors

### DIFF
--- a/src/inc/uffs/uffs.h
+++ b/src/inc/uffs/uffs.h
@@ -78,6 +78,7 @@ extern "C"{
 #define UEIOERR	11		/** I/O error from lower level flash operation */
 #define UENOTDIR 12		/** Not a directory */
 #define UEISDIR 13		/** Is a directory */    
+#define UERANGE 14  /** Read data out of page range */
 
 #define UEUNKNOWN_ERR	100	/** unknown error */
 

--- a/src/uffs/uffs_fs.c
+++ b/src/uffs/uffs_fs.c
@@ -1183,7 +1183,8 @@ int uffs_ReadObject(uffs_Object *obj, void *data, int len)
 
 		pageOfs = read_start % dev->com.pg_data_size;
 		if (pageOfs >= buf->data_len) {
-			//uffs_Perror(UFFS_MSG_NOISY, "read data out of page range ?");
+			uffs_Perror(UFFS_MSG_NOISY, "read data out of page range ?");
+			obj->err = UERANGE;
 			uffs_BufPut(dev, buf);
 			break;
 		}


### PR DESCRIPTION
Current version silently exits when out of range reads are performed - no logs, no error code. 

This change fixes that - it restores the logging and adds error code to notify upstream that operation failed. 